### PR TITLE
add the overlay

### DIFF
--- a/client/react/Macweb.js
+++ b/client/react/Macweb.js
@@ -44,6 +44,21 @@ class Macweb extends Component {
 
   componentDidMount() {
     $('img[usemap]').maphilight();
+
+    //in support of net neutrality as per https://github.com/fightforthefuture/battleforthenet-widget
+    window._bftn_options = {
+      theme: 'without', // @type {string}
+      org: 'fp', // @type {string}
+      disableGoogleAnalytics: true, // @type {boolean}
+    };
+    function loadBattleForNet() {
+         var script= document.createElement('script');
+         script.type= 'text/javascript';
+         script.src= 'https://widget.battleforthenet.com/widget.js';
+         script.async = true;
+         document.body.appendChild(script);
+    }
+    loadBattleForNet();
   }
 }
 


### PR DESCRIPTION
https://www.battleforthenet.com/july12/
https://github.com/fightforthefuture/battleforthenet-widget

I think macweb should join this campaign. The widget can be adjusted to be show at most X times per day. Currently it's set to the default of once per day, but maybe it should be more? The first link above talks about the project and the second link gives configuration details.